### PR TITLE
Deleting files before exporting/importing

### DIFF
--- a/crates/haze_core/src/error.rs
+++ b/crates/haze_core/src/error.rs
@@ -35,4 +35,18 @@ pub enum Error {
     #[error("cannot overwrite the world `{0}` as it already exists in `minecraftWorlds`")]
     #[diagnostic(help("do \"haze test --overwrite {0}\" if you want to overwrite it"))]
     CannotOverwriteWorld(String),
+
+    #[error("cannot delete directory `{0}` because permission to access some of its contents was denied")]
+    #[diagnostic(help("Make sure that the directory is not in use by another program"))]
+    CannotDeleteDirectory(String),
+
+    #[error(
+        "failed while trying to delete directory `{0}` and some of its contents may still exist"
+    )]
+    #[diagnostic(help("Make sure that the directory is not in use by another program"))]
+    CriticalDeleteDirectory(String),
+
+    #[error("cannot access all of the files in the directory `{0}`")]
+    #[diagnostic(help("Make sure that the directory is not in use by another program"))]
+    CannotAccessDirectory(String),
 }


### PR DESCRIPTION
This PR fixes the issue of Haze not cleaning the directories before overwriting them with the new files (during the import and export operations).

It also adds a test for the world files being used during the import command (the world shouldn't be opened in Minecraft when you import the files to your repository because this may cause importing files in invalid state).

The tests for the directory being used aren't perfectly safe. The directories are tested first (one file at a time) and than everything is deleted. It is possible that some program will start using some files in the directory after the tests are made and before the deletion.

---

Closes #14